### PR TITLE
change receiver if slot belongs to struct

### DIFF
--- a/parser/compiler.go
+++ b/parser/compiler.go
@@ -1321,6 +1321,8 @@ outer:
 
 		if receiver != this.RootWidgetName {
 			receiver = "this." + receiver
+		} else {
+			receiver = "this"
 		}
 
 		signal, signalParams := this.parseSignature(n.Signal)


### PR DESCRIPTION
As an example.

If we create a signal

```
   <sender>pushButton</sender>
   <signal>clicked()</signal>
   <receiver>Frame</receiver>
   <slot>slot1()</slot>
```

in which Frame is the name of top QFrame object

goqtuic will render it to be something like this:

```
func (this *UIFrame) SetupUI(Frame *widgets.QFrame) {
	Frame.SetObjectName("Frame")
	Frame.SetGeometry(core.NewQRect4(0, 0, 400, 300))
	this.PushButton = widgets.NewQPushButton(Frame)
	this.PushButton.SetObjectName("PushButton")
	this.PushButton.SetGeometry(core.NewQRect4(130, 130, 75, 23))


    this.RetranslateUi(Frame)

	this.PushButton.ConnectClicked(Frame.Slot1)
}
```

But frame is a pointer of widgets.QFrame, which we could not add method to a global QFrame type.

Indeed, this function should belong to this.Slot1.

```
func (this *UIFrame) SetupUI(Frame *widgets.QFrame) {
	Frame.SetObjectName("Frame")
	Frame.SetGeometry(core.NewQRect4(0, 0, 400, 300))
	this.PushButton = widgets.NewQPushButton(Frame)
	this.PushButton.SetObjectName("PushButton")
	this.PushButton.SetGeometry(core.NewQRect4(130, 130, 75, 23))


    this.RetranslateUi(Frame)

	this.PushButton.ConnectClicked(this.Slot1)
}
```

This patch will change Frame.Slot1 to this.Slot1.

After that, we create a file 

```
package uigen

func (this *UIFrame) Slot1(b bool) {
	
}
```

The original generated file works like a charm.

We could also regenerate it without changing anything.